### PR TITLE
Replace std::round with round

### DIFF
--- a/examples/Example3_SCD30_BLE_TTGO_Gadget/Example3_SCD30_BLE_TTGO_Gadget.ino
+++ b/examples/Example3_SCD30_BLE_TTGO_Gadget/Example3_SCD30_BLE_TTGO_Gadget.ino
@@ -145,7 +145,7 @@ void loop() {
       Serial.println(result[2]);
 
       // display CO2 value
-      displayCo2((uint16_t) std::round(result[0]));
+      displayCo2((uint16_t) round(result[0]));
     }
   }
 


### PR DESCRIPTION
Hi, cool example, works fine 👍
By following the guide for the TTGO T-Display example I came across one compilation error, removing "std::" just solved the issue.

```
C:\Users\xxx\Desktop\Example3_SCD30_BLE_TTGO_Gadget\Example3_SCD30_BLE_TTGO_Gadget.ino: In function 'void loop()':

Example3_SCD30_BLE_TTGO_Gadget:148:29: error: 'round' is not a member of 'std'

       displayCo2((uint16_t) std::round(result[0]));

                             ^
xxx\Example3_SCD30_BLE_TTGO_Gadget\Example3_SCD30_BLE_TTGO_Gadget.ino:148:29: note: suggested alternative:

In file included from C:\Users\xxx\AppData\Local\Arduino15\packages\esp32\hardware\esp32\1.0.3\cores\esp32/esp32-hal.h:34:0,

                 from C:\Users\xxx\AppData\Local\Arduino15\packages\esp32\hardware\esp32\1.0.3\cores\esp32/Arduino.h:35,

                 from sketch\Example3_SCD30_BLE_TTGO_Gadget.ino.cpp:1:

C:\Users\xxx\AppData\Local\Arduino15\packages\esp32\hardware\esp32\1.0.3/tools/sdk/include/newlib/math.h:278:15: note:   'round'

 extern double round _PARAMS((double));

               ^

exit status 1
'round' is not a member of 'std'
```