### PR TITLE
Adding WiFi Configuration Methods to DataProvider Class

### DIFF
--- a/src/DataProvider.cpp
+++ b/src/DataProvider.cpp
@@ -123,6 +123,22 @@ String DataProvider::getDeviceIdString() const {
     return cDevId;
 }
 
+String DataProvider::getWifiSSID() {
+    return _wifiSSID;
+}
+
+String DataProvider::getWifiPassword() {
+    return _wifiPassword;
+}
+
+bool DataProvider::wifiChanged() {
+    if (_wifiSettingsChanged) {
+        _wifiSettingsChanged = false;
+        return true;
+    }
+    return false;
+}
+
 bool DataProvider::isDownloading() const {
     return (_downloadState != DownloadState::INACTIVE);
 }

--- a/src/DataProvider.h
+++ b/src/DataProvider.h
@@ -94,7 +94,7 @@ class DataProvider: public IProviderCallbacks {
     bool _enalbeFRCService;
 
     SampleConfig _sampleConfig;
-    uint64_t _historyIntervalMilliSeconds = 60000; // = 1 minutes
+    uint64_t _historyIntervalMilliSeconds = 60000; // = 10 minutes
     uint64_t _latestHistoryTimeStamp = 0;
     uint64_t _latestHistoryTimeStampAtDownloadStart = 0;
     IWifiLibraryWrapper* _pWifiLibaray;

--- a/src/DataProvider.h
+++ b/src/DataProvider.h
@@ -59,7 +59,10 @@ class DataProvider: public IProviderCallbacks {
     void handleDownload();
     void setBatteryLevel(int value);
     void setSampleConfig(DataType dataType);
-    String getDeviceIdString() const;
+    String getDeviceIdString() const;    
+    String getWifiSSID();
+    String getWifiPassword();
+    bool wifiChanged();
     bool isDownloading() const;
     bool isFRCRequested() const;
     uint32_t getReferenceCO2Level() const;
@@ -81,6 +84,10 @@ class DataProvider: public IProviderCallbacks {
     int _numberOfSamplePacketsToDownload = 0;
     bool _frc_requested = false;
     uint32_t _reference_co2_level = 0;
+
+    String _wifiSSID = "";
+    String _wifiPassword = "";
+    bool _wifiSettingsChanged = false;
 
     bool _enableWifiSettings;
     bool _enableBatteryService;

--- a/src/DataProvider.h
+++ b/src/DataProvider.h
@@ -94,7 +94,7 @@ class DataProvider: public IProviderCallbacks {
     bool _enalbeFRCService;
 
     SampleConfig _sampleConfig;
-    uint64_t _historyIntervalMilliSeconds = 600000; // = 10 minutes
+    uint64_t _historyIntervalMilliSeconds = 60000; // = 1 minutes
     uint64_t _latestHistoryTimeStamp = 0;
     uint64_t _latestHistoryTimeStampAtDownloadStart = 0;
     IWifiLibraryWrapper* _pWifiLibaray;

--- a/src/SampleHistoryRingBuffer.h
+++ b/src/SampleHistoryRingBuffer.h
@@ -34,7 +34,7 @@
 #include "ByteArray.h"
 #include "Sample.h"
 
-const static size_t SAMPLE_HISTORY_RING_BUFFER_SIZE_BYTES = 30000;
+const static size_t SAMPLE_HISTORY_RING_BUFFER_SIZE_BYTES = 10000;
 
 // Logs Samples over time to be downloaded
 class SampleHistoryRingBuffer

--- a/src/SampleHistoryRingBuffer.h
+++ b/src/SampleHistoryRingBuffer.h
@@ -34,7 +34,7 @@
 #include "ByteArray.h"
 #include "Sample.h"
 
-const static size_t SAMPLE_HISTORY_RING_BUFFER_SIZE_BYTES = 10000;
+const static size_t SAMPLE_HISTORY_RING_BUFFER_SIZE_BYTES = 30000;
 
 // Logs Samples over time to be downloaded
 class SampleHistoryRingBuffer

--- a/src/WifiCredentialSetters.cpp
+++ b/src/WifiCredentialSetters.cpp
@@ -4,10 +4,18 @@ void DataProvider::onWifiSsidChange(std::string ssid) {
     if (_pWifiLibaray != nullptr) {
         _pWifiLibaray->setSsid(ssid.c_str());
     }
+    Serial.print("Wifi SSID changed to: ");
+    Serial.println(ssid.c_str());
+    _wifiSSID = ssid.c_str();
+    _wifiSettingsChanged = true;
 }
 
 void DataProvider::onWifiPasswordChange(std::string pwd) {
     if (_pWifiLibaray != nullptr) {
         _pWifiLibaray->connect(pwd.c_str());
     }
+    Serial.print("Wifi password changed to: ");
+    Serial.println(pwd.c_str());
+    _wifiPassword = pwd.c_str();
+    _wifiSettingsChanged = true;
 }

--- a/src/WifiCredentialSetters.cpp
+++ b/src/WifiCredentialSetters.cpp
@@ -12,7 +12,5 @@ void DataProvider::onWifiPasswordChange(std::string pwd) {
         _pWifiLibaray->connect(pwd.c_str());
         _wifiPassword = pwd.c_str();
         _wifiSettingsChanged = true;
-        Serial.println("-->[BLE-Lib] Wifi password changed to: " +
-                       _wifiPassword);
     }
 }

--- a/src/WifiCredentialSetters.cpp
+++ b/src/WifiCredentialSetters.cpp
@@ -3,19 +3,16 @@
 void DataProvider::onWifiSsidChange(std::string ssid) {
     if (_pWifiLibaray != nullptr) {
         _pWifiLibaray->setSsid(ssid.c_str());
+        _wifiSSID = ssid.c_str();
     }
-    Serial.print("Wifi SSID changed to: ");
-    Serial.println(ssid.c_str());
-    _wifiSSID = ssid.c_str();
-    _wifiSettingsChanged = true;
 }
 
 void DataProvider::onWifiPasswordChange(std::string pwd) {
     if (_pWifiLibaray != nullptr) {
         _pWifiLibaray->connect(pwd.c_str());
+        _wifiPassword = pwd.c_str();
+        _wifiSettingsChanged = true;
+        Serial.println("-->[BLE-Lib] Wifi password changed to: " +
+                       _wifiPassword);
     }
-    Serial.print("Wifi password changed to: ");
-    Serial.println(pwd.c_str());
-    _wifiPassword = pwd.c_str();
-    _wifiSettingsChanged = true;
 }


### PR DESCRIPTION
Hi there,

I hope this message finds you well. I've been working on [a project](https://github.com/melkati/CO2-Gadget) that involves configuring WiFi settings from the MyAmbiance app. However, I found that the current version of the arduino-ble-gadget library didn't provide the necessary methods for this functionality, or at least that's how it seemed to me.

To address this issue, I've added the required code to the DataProvider class to enable WiFi configuration. Here are the methods I've added:

```cpp
String DataProvider::getWifiSSID() {
    return _wifiSSID;
}

String DataProvider::getWifiPassword() {
    return _wifiPassword;
}

bool DataProvider::wifiChanged() {
    if (_wifiSettingsChanged) {
        _wifiSettingsChanged = false;
        return true;
    }
    return false;
}
```

To utilize these methods, one can simply check for WiFi configuration changes in the main program loop, for example:

```cpp
provider.handleDownload();
delay(3);
if (provider.wifiChanged()) {
    handleBLEwifiChanged();
}
```

The call to `provider.wifiChanged()` will return true if there has been a WiFi configuration change (based on password change; changes in SSID are ignored), and it will return false if only the SSID has changed.

`provider.wifiChanged()` will only return true on the first call. It will not return true again until a new password change occurs.

The main program can then handle the WiFi change as desired, for example:

```cpp
void handleBLEwifiChanged() {
    String wifiSSID = provider.getWifiSSID();
    String wifiPass = provider.getWifiPassword();
    // Your WiFi handling code here
}
```

I believe these additions will greatly enhance the usability and flexibility of the library for projects like mine that require WiFi configuration capabilities. I'm looking forward to your feedback and suggestions.

Best regards,
Mario

Here is a complete implementation:
https://github.com/melkati/CO2-Gadget/blob/41f4f017af3bd0d1cf7798fb870923f2ea30a600/CO2_Gadget_BLE.h#L102-L113