### PR TITLE
fixe age latest sample in download header

### DIFF
--- a/src/DataProvider.cpp
+++ b/src/DataProvider.cpp
@@ -137,7 +137,7 @@ std::string DataProvider::_buildAdvertisementData() {
 DownloadHeader DataProvider::_buildDownloadHeader() {
     DownloadHeader header;
     uint32_t age = static_cast<uint32_t>(
-        ((millis() - _latestHistoryTimeStampAtDownloadStart) / 1000));
+        millis() - _latestHistoryTimeStampAtDownloadStart);
     header.setDownloadSampleType(_sampleConfig.downloadType);
     header.setIntervalMilliSeconds(_historyIntervalMilliSeconds);
     header.setAgeOfLatestSampleMilliSeconds(age);


### PR DESCRIPTION
the age of the latest sample, thus how long ago the last sample was logged, should be in milliseconds