### PR TITLE
send last 2 bytes of mac as device id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Allow to request only the last X samples when doing a data download (implement Requested Samples Characterisitc on Download Service)
 
+### Fixed
+- use the last 2 Bytes of Mac Address as Device ID in BLE Advertisment (fixes mismatch of logged id and id appearing in MyAmbience as mentiond in https://github.com/Sensirion/arduino-ble-gadget/issues/44)
+
 ## [1.3.2] - 2024-06-19
 
 ### Fixed

--- a/src/AdvertisementHeader.cpp
+++ b/src/AdvertisementHeader.cpp
@@ -12,6 +12,7 @@ void AdvertisementHeader::writeSampleType(uint8_t sampleType) {
     _writeByte(sampleType, 3);
 }
 
-void AdvertisementHeader::writeDeviceId(uint16_t deviceID) {
-    _write16BitBigEndian(deviceID, 4);
+void AdvertisementHeader::writeDeviceId(uint8_t deviceIDHigh, uint8_t deviceIDLow) {
+    _writeByte(deviceIDHigh, 4);
+    _writeByte(deviceIDLow, 5);
 }

--- a/src/AdvertisementHeader.h
+++ b/src/AdvertisementHeader.h
@@ -40,7 +40,7 @@ class AdvertisementHeader: public ByteArray<ADVERTISEMENT_HEADER_SIZE_BYTES> {
     void writeCompanyId(uint16_t companyID);
     void writeSensirionAdvertisementType(uint8_t advType);
     void writeSampleType(uint8_t sampleType);
-    void writeDeviceId(uint16_t deviceID);
+    void writeDeviceId(uint8_t deviceIDHigh, uint8_t deviceIDLow);
 };
 
 #endif /* _ADVERTISEMENT_HEADER_H_ */

--- a/src/DataProvider.cpp
+++ b/src/DataProvider.cpp
@@ -13,7 +13,9 @@ void DataProvider::begin() {
     // Use part of MAC address as device id
     std::string macAddress = _BLELibrary.getDeviceAddress();
     _advertisementHeader.writeDeviceId(
-        strtol(macAddress.substr(12, 17).c_str(), NULL, 16));
+        static_cast<uint8_t>(strtol(macAddress.substr(12, 14).c_str(), NULL, 16)),
+        static_cast<uint8_t>(strtol(macAddress.substr(15, 17).c_str(), NULL, 16))
+    );
 
     _BLELibrary.setAdvertisingData(_buildAdvertisementData());
     _BLELibrary.startAdvertising();


### PR DESCRIPTION
instead of only sending the last byte
this fixes mismatch of logged device id on Serial output of the ESP and device id which appears in MyAmbience (as mentioned in issue #44