### PR TITLE
Callbacks for interval change and FRC request

### DIFF
--- a/src/DataProvider.cpp
+++ b/src/DataProvider.cpp
@@ -269,6 +269,9 @@ void DataProvider::onHistoryIntervalChange(int interval) {
     _sampleHistory.reset();
     _BLELibrary.characteristicSetValue(
         NUMBER_OF_SAMPLES_UUID, _sampleHistory.numberOfSamplesInHistory());
+    if (_callbackHistoryIntervalChange != nullptr) {
+        _callbackHistoryIntervalChange(interval);
+    }
 }
 
 void DataProvider::onConnectionEvent() {
@@ -281,8 +284,12 @@ void DataProvider::onDownloadRequest() {
 }
 
 void DataProvider::onFRCRequest(uint16_t reference_co2_level) {
-    _frc_requested = true;
-    _reference_co2_level = reference_co2_level;
+    if (_callbackFRC != nullptr) {
+        _callbackFRC(reference_co2_level);
+    } else {
+        _frc_requested = true;
+        _reference_co2_level = reference_co2_level;
+    }
 }
 
 void DataProvider::onNrOfSamplesRequest(int nr_of_samples) {

--- a/src/DataProvider.h
+++ b/src/DataProvider.h
@@ -47,11 +47,15 @@ class DataProvider: public IProviderCallbacks {
                           bool enableWifiSettings = false,
                           bool enableBatteryService = false,
                           bool enableFRCService = false,
+                          void (*CallbackFRC)(uint16_t) = nullptr,
+                          void (*CallbackHistoryIntervalChange)(int) = nullptr,
                           IWifiLibraryWrapper* pWifiLibrary = nullptr)
         : _BLELibrary(libraryWrapper), _enableWifiSettings(enableWifiSettings),
           _enableBatteryService(enableBatteryService),
           _enableFRCService(enableFRCService), _enableAltDeviceName(false),
           _sampleConfig(sampleConfigSelector.at(dataType)),
+          _callbackFRC(CallbackFRC),
+          _callbackHistoryIntervalChange(CallbackHistoryIntervalChange),
           _pWifiLibaray(pWifiLibrary){};
     ~DataProvider(){};
     void begin();
@@ -104,6 +108,10 @@ class DataProvider: public IProviderCallbacks {
     uint64_t _latestHistoryTimeStamp = 0;
     uint64_t _latestHistoryTimeStampAtDownloadStart = 0;
     IWifiLibraryWrapper* _pWifiLibaray;
+
+    // ExternalCallbacks
+    void (*_callbackFRC)(uint16_t);
+    void (*_callbackHistoryIntervalChange)(int);
 
     // ProviderCallbacks
     void onHistoryIntervalChange(int interval) override;


### PR DESCRIPTION
Instead of polling for FRC request there is now an option to register a callback function which is called on request.
Furthermore an option for a callback function on interval change is given.