### PR TITLE
Callbacks and new characteristics

### DIFF
--- a/src/DataProvider.cpp
+++ b/src/DataProvider.cpp
@@ -199,6 +199,16 @@ void DataProvider::_setupBLEInfrastructure() {
     _BLELibrary.init();
     _BLELibrary.createServer();
 
+    _setupBLEServices();
+
+    _BLELibrary.setProviderCallbacks(this);
+    _BLELibrary.characteristicSetValue(SAMPLE_HISTORY_INTERVAL_UUID,
+                                       _historyIntervalMilliSeconds);
+    _BLELibrary.characteristicSetValue(
+        NUMBER_OF_SAMPLES_UUID, _sampleHistory.numberOfSamplesInHistory());
+}
+
+void DataProvider::_setupBLEServices() {
     // Download Service
     _BLELibrary.createService(DOWNLOAD_SERVICE_UUID);
     _BLELibrary.createCharacteristic(DOWNLOAD_SERVICE_UUID,
@@ -256,12 +266,6 @@ void DataProvider::_setupBLEInfrastructure() {
         _BLELibrary.characteristicSetValue(SCD_FRC_REQUEST_UUID, 0);
         _BLELibrary.startService(SCD_SERVICE_UUID);
     }
-
-    _BLELibrary.setProviderCallbacks(this);
-    _BLELibrary.characteristicSetValue(SAMPLE_HISTORY_INTERVAL_UUID,
-                                       _historyIntervalMilliSeconds);
-    _BLELibrary.characteristicSetValue(
-        NUMBER_OF_SAMPLES_UUID, _sampleHistory.numberOfSamplesInHistory());
 }
 
 void DataProvider::onHistoryIntervalChange(int interval) {

--- a/src/DataProvider.h
+++ b/src/DataProvider.h
@@ -40,6 +40,9 @@
 #include "Sensirion_UPT_Core.h"
 #include <string>
 
+class SCDDataProvider;
+class SCD4xDataProvider;
+
 class DataProvider: public IProviderCallbacks {
   public:
     explicit DataProvider(IBLELibraryWrapper& libraryWrapper,
@@ -76,12 +79,15 @@ class DataProvider: public IProviderCallbacks {
     void setAltDeviceName(std::string altDeviceName);
 
   private:
+    friend class SCDDataProvider;
+    friend class SCD4xDataProvider;
     std::string _buildAdvertisementData();
     DownloadHeader _buildDownloadHeader();
     DownloadPacket _buildDownloadPacket();
     int _numberOfPacketsRequired(int numberOfSamples) const;
     IBLELibraryWrapper& _BLELibrary;
     void _setupBLEInfrastructure();
+    virtual void _setupBLEServices();
     Sample _currentSample;
     AdvertisementHeader _advertisementHeader;
     SampleHistoryRingBuffer _sampleHistory;

--- a/src/IBLELibraryWrapper.h
+++ b/src/IBLELibraryWrapper.h
@@ -67,9 +67,23 @@ static const char* const SCD_SERVICE_UUID =
     "00007000-b38d-4985-720e-0f993a68ee41";
 static const char* const SCD_FRC_REQUEST_UUID =
     "00007004-b38d-4985-720e-0f993a68ee41";
+static const char* const SCD_REQUEST_UUID_MEASUREMENT_INTERVAL =
+    "00007005-b38d-4985-720e-0f993a68ee41";
+static const char* const SCD_REQUEST_UUID_TEMPERATURE_OFFSET =
+    "00007006-b38d-4985-720e-0f993a68ee41";
+static const char* const SCD_REQUEST_UUID_ALTITUDE_SETTING =
+    "00007007-b38d-4985-720e-0f993a68ee41";
+static const char* const SCD_REQUEST_UUID_ASC_STATUS =
+    "00007008-b38d-4985-720e-0f993a68ee41";
+static const char* const SCD_REQUEST_UUID_ASC_INTERVAL =
+    "00007009-b38d-4985-720e-0f993a68ee41";
+static const char* const SCD_REQUEST_UUID_ASC_INITIAL_INTERVAL =
+    "00007010-b38d-4985-720e-0f993a68ee41";
+static const char* const SCD_REQUEST_UUID_ASC_TARGET =
+    "00007011-b38d-4985-720e-0f993a68ee41";
 
 static const unsigned int MAX_NUMBER_OF_SERVICES = 4;
-static const unsigned int MAX_NUMBER_OF_CHARACTERISTICS = 12;
+static const unsigned int MAX_NUMBER_OF_CHARACTERISTICS = 16;
 
 enum Permission {
     READWRITE_PERMISSION,

--- a/src/IBLELibraryWrapper.h
+++ b/src/IBLELibraryWrapper.h
@@ -32,6 +32,7 @@
 #define _I_BLE_LIBRARY_WRAPPER_H_
 
 #include "IProviderCallbacks.h"
+#include <functional>
 #include <string>
 
 const char* const GADGET_NAME = "S";
@@ -115,6 +116,9 @@ class IBLELibraryWrapper {
     virtual bool characteristicNotify(const char* uuid) = 0;
     virtual void
     setProviderCallbacks(IProviderCallbacks* providerCallbacks) = 0;
+    virtual void
+    registerCallback(const char* characteristicUuid,
+                     std::function<void(std::string)> callbackFunction) = 0;
 };
 
 #endif /* _I_BLE_LIBRARY_WRAPPER_H_ */

--- a/src/NimBLELibraryWrapper.h
+++ b/src/NimBLELibraryWrapper.h
@@ -33,6 +33,8 @@
 
 #include "IBLELibraryWrapper.h"
 #include <NimBLECharacteristic.h>
+#include <functional>
+#include <string>
 
 struct WrapperPrivateData;
 
@@ -70,6 +72,7 @@ class NimBLELibraryWrapper: public IBLELibraryWrapper {
     std::string characteristicGetValue(const char* uuid) override;
     bool characteristicNotify(const char* uuid) override;
     void setProviderCallbacks(IProviderCallbacks* providerCallbacks) override;
+    void registerCallback(const char* characteristicUuid, std::function<void(std::string)> callbackFunction);
 
   private:
     void _deinit();

--- a/src/SCD4xDataProvider.cpp
+++ b/src/SCD4xDataProvider.cpp
@@ -1,0 +1,61 @@
+#include "SCD4xDataProvider.h"
+
+void SCD4xDataProvider::_setupSCDBLECharacteristics() {
+    SCDDataProvider::_setupSCDBLECharacteristics();
+    if (_enableASCIntervalCharacteristic) {
+        _BLELibrary.createCharacteristic(SCD_SERVICE_UUID,
+                                         SCD_REQUEST_UUID_ASC_INTERVAL,
+                                         Permission::READWRITE_PERMISSION);
+        _BLELibrary.characteristicSetValue(SCD_REQUEST_UUID_ASC_INTERVAL, 0);
+    }
+    if (_enableASCInitIntervalCharacteristic) {
+        _BLELibrary.createCharacteristic(SCD_SERVICE_UUID,
+                                         SCD_REQUEST_UUID_ASC_INITIAL_INTERVAL,
+                                         Permission::READWRITE_PERMISSION);
+        _BLELibrary.characteristicSetValue(
+            SCD_REQUEST_UUID_ASC_INITIAL_INTERVAL, 0);
+    }
+    if (_enableASCTargetCharacteristic) {
+        _BLELibrary.createCharacteristic(SCD_SERVICE_UUID,
+                                         SCD_REQUEST_UUID_ASC_TARGET,
+                                         Permission::READWRITE_PERMISSION);
+        _BLELibrary.characteristicSetValue(SCD_REQUEST_UUID_ASC_TARGET, 0);
+    }
+}
+
+void SCD4xDataProvider::enableASCIntervalCharacteristic(
+    std::function<void(std::string)> callbackFunction) {
+    _BLELibrary.registerCallback(SCD_REQUEST_UUID_ASC_INTERVAL,
+                                 callbackFunction);
+    _enableSCDService = true;
+    _enableASCIntervalCharacteristic = true;
+}
+
+void SCD4xDataProvider::enableASCInitIntervalCharacteristic(
+    std::function<void(std::string)> callbackFunction) {
+    _BLELibrary.registerCallback(SCD_REQUEST_UUID_ASC_INITIAL_INTERVAL,
+                                 callbackFunction);
+    _enableSCDService = true;
+    _enableASCInitIntervalCharacteristic = true;
+}
+
+void SCD4xDataProvider::enableASCTargetCharacteristic(
+    std::function<void(std::string)> callbackFunction) {
+    _BLELibrary.registerCallback(SCD_REQUEST_UUID_ASC_TARGET, callbackFunction);
+    _enableSCDService = true;
+    _enableASCTargetCharacteristic = true;
+}
+
+void SCD4xDataProvider::setASCInitInterval(uint16_t value) {
+    _BLELibrary.characteristicSetValue(SCD_REQUEST_UUID_ASC_INITIAL_INTERVAL,
+                                       (int)value);
+}
+
+void SCD4xDataProvider::setASCInterval(uint16_t value) {
+    _BLELibrary.characteristicSetValue(SCD_REQUEST_UUID_ASC_INTERVAL,
+                                       (int)value);
+}
+
+void SCD4xDataProvider::setASCTarget(uint16_t value) {
+    _BLELibrary.characteristicSetValue(SCD_REQUEST_UUID_ASC_TARGET, (int)value);
+}

--- a/src/SCD4xDataProvider.h
+++ b/src/SCD4xDataProvider.h
@@ -1,0 +1,33 @@
+#ifndef _SCD4X_DATA_PROVIDER_H_
+#define _SCD4X_DATA_PROVIDER_H_
+
+#include "SCDDataProvider.h"
+#include <functional>
+
+class SCD4xDataProvider: public SCDDataProvider {
+  public:
+    explicit SCD4xDataProvider(IBLELibraryWrapper& libraryWrapper,
+                               DataType dataType = T_RH_V3,
+                               bool enableWifiSettings = false,
+                               bool enableBatteryService = false,
+                               IWifiLibraryWrapper* pWifiLibrary = nullptr)
+        : SCDDataProvider(libraryWrapper, dataType, enableWifiSettings,
+                          enableBatteryService, pWifiLibrary) {};
+    void enableASCIntervalCharacteristic(
+        std::function<void(std::string)> callbackFunction);
+    void enableASCInitIntervalCharacteristic(
+        std::function<void(std::string)> callbackFunction);
+    void enableASCTargetCharacteristic(
+        std::function<void(std::string)> callbackFunction);
+    void setASCInitInterval(uint16_t value);
+    void setASCInterval(uint16_t value);
+    void setASCTarget(uint16_t value);
+
+  private:
+    void _setupSCDBLECharacteristics() override;
+    bool _enableASCIntervalCharacteristic = false;
+    bool _enableASCInitIntervalCharacteristic = false;
+    bool _enableASCTargetCharacteristic = false;
+};
+
+#endif /* _SCD4X_DATA_PROVIDER_H_ */

--- a/src/SCDDataProvider.cpp
+++ b/src/SCDDataProvider.cpp
@@ -1,0 +1,100 @@
+#include "SCDDataProvider.h"
+
+void SCDDataProvider::_setupSCDBLECharacteristics() {
+    if (_enableForcedRecalibrationCharacteristic) {
+        _BLELibrary.createCharacteristic(SCD_SERVICE_UUID, SCD_FRC_REQUEST_UUID,
+                                         Permission::READWRITE_PERMISSION);
+        _BLELibrary.characteristicSetValue(SCD_FRC_REQUEST_UUID, 0);
+    }
+    if (_enableMeasurementIntervalCharacteristic) {
+        _BLELibrary.createCharacteristic(SCD_SERVICE_UUID,
+                                         SCD_REQUEST_UUID_MEASUREMENT_INTERVAL,
+                                         Permission::READWRITE_PERMISSION);
+        _BLELibrary.characteristicSetValue(
+            SCD_REQUEST_UUID_MEASUREMENT_INTERVAL, 0);
+    }
+    if (_enableTempOffsetCharacteristic) {
+        _BLELibrary.createCharacteristic(SCD_SERVICE_UUID,
+                                         SCD_REQUEST_UUID_TEMPERATURE_OFFSET,
+                                         Permission::READWRITE_PERMISSION);
+        _BLELibrary.characteristicSetValue(SCD_REQUEST_UUID_TEMPERATURE_OFFSET,
+                                           0);
+    }
+    if (_enableAltitudeCharacteristic) {
+        _BLELibrary.createCharacteristic(SCD_SERVICE_UUID,
+                                         SCD_REQUEST_UUID_ALTITUDE_SETTING,
+                                         Permission::READWRITE_PERMISSION);
+        _BLELibrary.characteristicSetValue(SCD_REQUEST_UUID_ALTITUDE_SETTING,
+                                           0);
+    }
+    if (_enableASCCharacteristic) {
+        _BLELibrary.createCharacteristic(SCD_SERVICE_UUID,
+                                         SCD_REQUEST_UUID_ASC_STATUS,
+                                         Permission::READWRITE_PERMISSION);
+        _BLELibrary.characteristicSetValue(SCD_REQUEST_UUID_ASC_STATUS, 0);
+    }
+}
+
+void SCDDataProvider::_setupBLEServices() {
+    DataProvider::_setupBLEServices();
+    // SCD Service
+    if (_enableSCDService) {
+        _BLELibrary.createService(SCD_SERVICE_UUID);
+        _setupSCDBLECharacteristics();
+        _BLELibrary.startService(SCD_SERVICE_UUID);
+    }
+}
+
+void SCDDataProvider::enableMeasurementIntervalCharacteristic(
+    std::function<void(std::string)> callbackFunction) {
+    _BLELibrary.registerCallback(SCD_REQUEST_UUID_MEASUREMENT_INTERVAL,
+                                 callbackFunction);
+    _enableSCDService = true;
+    _enableMeasurementIntervalCharacteristic = true;
+}
+
+void SCDDataProvider::enableTempOffsetCharacteristic(
+    std::function<void(std::string)> callbackFunction) {
+    _BLELibrary.registerCallback(SCD_REQUEST_UUID_TEMPERATURE_OFFSET,
+                                 callbackFunction);
+    _enableSCDService = true;
+    _enableTempOffsetCharacteristic = true;
+}
+
+void SCDDataProvider::enableAltitudeCharacteristic(
+    std::function<void(std::string)> callbackFunction) {
+    _BLELibrary.registerCallback(SCD_REQUEST_UUID_ALTITUDE_SETTING,
+                                 callbackFunction);
+    _enableSCDService = true;
+    _enableAltitudeCharacteristic = true;
+}
+
+void SCDDataProvider::enableForcedRecalibrationCharacteristic(
+    std::function<void(std::string)> callbackFunction) {
+    _BLELibrary.registerCallback(SCD_FRC_REQUEST_UUID, callbackFunction);
+    _enableSCDService = true;
+    _enableForcedRecalibrationCharacteristic = true;
+}
+
+void SCDDataProvider::enableASCCharacteristic(
+    std::function<void(std::string)> callbackFunction) {
+    _BLELibrary.registerCallback(SCD_REQUEST_UUID_ASC_STATUS, callbackFunction);
+    _enableSCDService = true;
+    _enableASCCharacteristic = true;
+}
+
+void SCDDataProvider::setASCStatus(uint16_t value) {
+    _BLELibrary.characteristicSetValue(SCD_REQUEST_UUID_ASC_STATUS, (int)value);
+}
+void SCDDataProvider::setMeasurementInterval(uint16_t value) {
+    _BLELibrary.characteristicSetValue(SCD_REQUEST_UUID_MEASUREMENT_INTERVAL,
+                                       (int)value);
+}
+void SCDDataProvider::setTempOffset(uint16_t value) {
+    _BLELibrary.characteristicSetValue(SCD_REQUEST_UUID_TEMPERATURE_OFFSET,
+                                       (int)value);
+}
+void SCDDataProvider::setAltitude(uint16_t value) {
+    _BLELibrary.characteristicSetValue(SCD_REQUEST_UUID_ALTITUDE_SETTING,
+                                       (int)value);
+}

--- a/src/SCDDataProvider.h
+++ b/src/SCDDataProvider.h
@@ -1,0 +1,46 @@
+#ifndef _SCD_DATA_PROVIDER_H_
+#define _SCD_DATA_PROVIDER_H_
+
+#include "DataProvider.h"
+#include <functional>
+
+class SCD4xDataProvider;
+
+class SCDDataProvider: public DataProvider {
+  public:
+    explicit SCDDataProvider(IBLELibraryWrapper& libraryWrapper,
+                             DataType dataType = T_RH_V3,
+                             bool enableWifiSettings = false,
+                             bool enableBatteryService = false,
+                             IWifiLibraryWrapper* pWifiLibrary = nullptr)
+        : DataProvider(libraryWrapper, dataType, enableWifiSettings,
+                       enableBatteryService, false, pWifiLibrary) {};
+
+    void enableMeasurementIntervalCharacteristic(
+        std::function<void(std::string)> callbackFunction);
+    void enableTempOffsetCharacteristic(
+        std::function<void(std::string)> callbackFunction);
+    void enableAltitudeCharacteristic(
+        std::function<void(std::string)> callbackFunction);
+    void enableForcedRecalibrationCharacteristic(
+        std::function<void(std::string)> callbackFunction);
+    void
+    enableASCCharacteristic(std::function<void(std::string)> callbackFunction);
+    void setASCStatus(uint16_t value);
+    void setMeasurementInterval(uint16_t value);
+    void setTempOffset(uint16_t value);
+    void setAltitude(uint16_t value);
+
+  private:
+    friend class SCD4xDataProvider;
+    virtual void _setupSCDBLECharacteristics();
+    void _setupBLEServices() override;
+    bool _enableAltitudeCharacteristic = false;
+    bool _enableTempOffsetCharacteristic = false;
+    bool _enableMeasurementIntervalCharacteristic = false;
+    bool _enableForcedRecalibrationCharacteristic = false;
+    bool _enableASCCharacteristic = false;
+    bool _enableSCDService = false;
+};
+
+#endif /* _SCD_DATA_PROVIDER_H_ */

--- a/src/Sensirion_Gadget_BLE.h
+++ b/src/Sensirion_Gadget_BLE.h
@@ -33,6 +33,8 @@
 
 #include "Arduino.h"
 #include "DataProvider.h"
+#include "SCDDataProvider.h"
+#include "SCD4xDataProvider.h"
 #include "NimBLELibraryWrapper.h"
 
 #endif /* _SENSIRION_GADGET_BLE_H_ */


### PR DESCRIPTION
Here is some code that enables SCD users to get informed about writings to BLE characteristics with callback functions.
Therefore new DataProviders are created- SCDDataProvider and  SCD4xDataProvider specially for SCD4x devices.
